### PR TITLE
Add support for precise date boundary control in SearchRequest with:

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -20,6 +20,7 @@ func TestAuthenticationMethod(t *testing.T) {
 
 		want := "Bearer a-test-token"
 		got := r.Header.Get("Authorization")
+
 		if got != want {
 			fail <- fmt.Errorf(
 				"unexpected authorization token value: want %q got %q",


### PR DESCRIPTION
- BoundaryType enum (Inclusive/Exclusive)
- Created/Updated DateRange fields
- Support for all OpenContent date filter parameters

Maintains backward compatibility while enabling flexible date queries.